### PR TITLE
Revert "Try to add dependabot for rust"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,4 @@ updates:
     # default location of `.github/workflows`
     directory: "/"
     schedule:
-      interval: "weekly"
-  - package-ecosystem: "cargo"
-    directory: "/"
-    schedule:
-      interval: "weekly"
+      interval: "daily"


### PR DESCRIPTION
Reverts Semptic/rust-project-template#3

Dependabot doesn't work with the template variables in the toml files.